### PR TITLE
DX-2967 Fix Bug in `BandwidthCallbackMessage` Model

### DIFF
--- a/Bandwidth.Standard/Messaging/Models/BandwidthCallbackMessage.cs
+++ b/Bandwidth.Standard/Messaging/Models/BandwidthCallbackMessage.cs
@@ -40,7 +40,7 @@ namespace Bandwidth.Standard.Messaging.Models
             string time = null,
             string type = null,
             string to = null,
-            string errorCode = null,
+            int? errorCode = null,
             string description = null,
             Models.BandwidthMessage message = null)
         {
@@ -74,7 +74,7 @@ namespace Bandwidth.Standard.Messaging.Models
         /// Gets or sets ErrorCode.
         /// </summary>
         [JsonProperty("errorCode", NullValueHandling = NullValueHandling.Ignore)]
-        public string ErrorCode { get; set; }
+        public int? ErrorCode { get; set; }
 
         /// <summary>
         /// Gets or sets Description.
@@ -167,7 +167,7 @@ namespace Bandwidth.Standard.Messaging.Models
             toStringOutput.Add($"this.Time = {(this.Time == null ? "null" : this.Time == string.Empty ? "" : this.Time)}");
             toStringOutput.Add($"this.Type = {(this.Type == null ? "null" : this.Type == string.Empty ? "" : this.Type)}");
             toStringOutput.Add($"this.To = {(this.To == null ? "null" : this.To == string.Empty ? "" : this.To)}");
-            toStringOutput.Add($"this.ErrorCode = {(this.ErrorCode == null ? "null" : this.ErrorCode == string.Empty ? "" : this.ErrorCode)}");
+            toStringOutput.Add($"this.ErrorCode = {(this.ErrorCode == null ? "null" : this.ErrorCode.ToString())}");
             toStringOutput.Add($"this.Description = {(this.Description == null ? "null" : this.Description == string.Empty ? "" : this.Description)}");
             toStringOutput.Add($"this.Message = {(this.Message == null ? "null" : this.Message.ToString())}");
         }

--- a/Bandwidth.StandardTests/Messaging/BandwidthCallbackMessageTests.cs
+++ b/Bandwidth.StandardTests/Messaging/BandwidthCallbackMessageTests.cs
@@ -1,0 +1,26 @@
+using Bandwidth.Standard.Messaging.Models;
+using Xunit;
+
+namespace Bandwidth.StandardTests.Messaging
+{
+    public class BandwidthCallbackMessageTests
+    {
+        [Fact]
+        public void InitializeMessagingCallbackModel()
+        {
+            BandwidthMessage testMessage = new BandwidthMessage();
+
+            BandwidthCallbackMessage testCallback = new BandwidthCallbackMessage(
+                time: "2016-09-14T18:20:16Z",
+                type: "message-failed",
+                to: "+52345678903",
+                errorCode: 4432,
+                description: "forbidden to country",
+                message: testMessage
+            );
+
+            Assert.Equal("BandwidthCallbackMessage : (this.Time = 2016-09-14T18:20:16Z, this.Type = message-failed, this.To = +52345678903, this.ErrorCode = 4432, this.Description = forbidden to country, this.Message = BandwidthMessage : (this.Id = null, this.Owner = null, this.ApplicationId = null, this.Time = null, this.SegmentCount = null, this.Direction = null, this.To = null, this.From = null, this.Media = null, this.Text = null, this.Tag = null, this.Priority = null))", testCallback.ToString());
+            Assert.IsType<int>(testCallback.ErrorCode);
+        }
+    }
+}


### PR DESCRIPTION
`BandwidthCallbackMessage.ErrorCode` was incorrectly defined as a string. This change sets it to the correct type, `int`.