### PR TITLE
SWI-2827 Add Repo to Service Catalog

### DIFF
--- a/.bandwidth/catalog-info.yaml
+++ b/.bandwidth/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  schemaVersion: v1.0.0
+  name: csharp-sdk-location
+  description: Links to additional entities in the csharp-sdk repository.
+  annotations:
+    github.com/project-slug: Bandwidth/csharp-sdk
+spec:
+  targets:
+    - ./component.yaml

--- a/.bandwidth/component.yaml
+++ b/.bandwidth/component.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  schemaVersion: v1.0.0
+  name: csharp-sdk
+  description: C# sdk
+  annotations:
+    github.com/project-slug: Bandwidth/csharp-sdk
+  organization: BW
+  costCenter: UNKNOWN
+  buildPlatform: GitHub Actions
+spec:
+  type: Library
+  owner: github/band-swi
+  lifecycle: Available


### PR DESCRIPTION
Auto-generated by the Backstage Service Catalog. Adds a `catalog-info.yaml` Location and `component.yaml` Component to represent this repository.